### PR TITLE
Set a consistent window location

### DIFF
--- a/MouseJiggler/MainForm.cs
+++ b/MouseJiggler/MainForm.cs
@@ -47,6 +47,7 @@ namespace ArkaneSystems.MouseJiggler
         {
             if (this.JiggleOnStartup)
                 this.cbJiggling.Checked = true;
+            this.SetDesktopLocation (150, 150);
         }
 
         private void UpdateNotificationAreaText ()


### PR DESCRIPTION
Whenever I start up mousejiggler, I have to hunt for where the window ends up. This makes a consistent location.

I'd prefer putting it in the top right corner of the primary display, but that's more than a single line and is harder to test.