### PR TITLE
Upgraded to .NET 7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,4 +176,4 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 /.vs
-/MouseJiggler/.vs/MouseJiggler/DesignTimeBuild/.dtbcache.v2
+/MouseJiggler/.vs

--- a/MouseJiggler/MouseJiggler.csproj
+++ b/MouseJiggler/MouseJiggler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>ArkaneSystems.MouseJiggler</RootNamespace>
     <Nullable>enable</Nullable>

--- a/MouseJiggler/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/MouseJiggler/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,7 +6,11 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net5.0-windows\publish\</PublishDir>
+    <PublishDir>bin\Release\net7.0-windows\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Updated solution to the latest .NET version
- Updated path of Publish profile to reflect the correct naming (no longer net5.0)
- Updated .gitignore file to exclude VS-specific folder (MouseJiggler/.vs)