### PR TITLE
Extend jiggle time to a maximum of 3h (10800 seconds) - fixes #78

### DIFF
--- a/MouseJiggler/MainForm.Designer.cs
+++ b/MouseJiggler/MainForm.Designer.cs
@@ -29,189 +29,198 @@ namespace ArkaneSystems.MouseJiggler
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-            this.jiggleTimer = new System.Windows.Forms.Timer(this.components);
-            this.flpLayout = new System.Windows.Forms.FlowLayoutPanel();
-            this.panelBase = new System.Windows.Forms.Panel();
-            this.cmdAbout = new System.Windows.Forms.Button();
-            this.cmdTrayify = new System.Windows.Forms.Button();
-            this.cbSettings = new System.Windows.Forms.CheckBox();
-            this.cbJiggling = new System.Windows.Forms.CheckBox();
-            this.panelSettings = new System.Windows.Forms.Panel();
-            this.lbPeriod = new System.Windows.Forms.Label();
-            this.tbPeriod = new System.Windows.Forms.TrackBar();
-            this.cbMinimize = new System.Windows.Forms.CheckBox();
-            this.cbZen = new System.Windows.Forms.CheckBox();
-            this.niTray = new System.Windows.Forms.NotifyIcon(this.components);
-            this.flpLayout.SuspendLayout();
-            this.panelBase.SuspendLayout();
-            this.panelSettings.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tbPeriod)).BeginInit();
-            this.SuspendLayout();
+            jiggleTimer = new System.Windows.Forms.Timer(components);
+            flpLayout = new System.Windows.Forms.FlowLayoutPanel();
+            panelBase = new System.Windows.Forms.Panel();
+            cmdAbout = new System.Windows.Forms.Button();
+            cmdTrayify = new System.Windows.Forms.Button();
+            cbSettings = new System.Windows.Forms.CheckBox();
+            cbJiggling = new System.Windows.Forms.CheckBox();
+            panelSettings = new System.Windows.Forms.Panel();
+            lbPeriod = new System.Windows.Forms.Label();
+            tbPeriod = new System.Windows.Forms.TrackBar();
+            cbMinimize = new System.Windows.Forms.CheckBox();
+            cbZen = new System.Windows.Forms.CheckBox();
+            niTray = new System.Windows.Forms.NotifyIcon(components);
+            flpLayout.SuspendLayout();
+            panelBase.SuspendLayout();
+            panelSettings.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)tbPeriod).BeginInit();
+            SuspendLayout();
             // 
             // jiggleTimer
             // 
-            this.jiggleTimer.Interval = 1000;
-            this.jiggleTimer.Tick += new System.EventHandler(this.jiggleTimer_Tick);
+            jiggleTimer.Interval = 1000;
+            jiggleTimer.Tick += jiggleTimer_Tick;
             // 
             // flpLayout
             // 
-            this.flpLayout.AutoSize = true;
-            this.flpLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.flpLayout.Controls.Add(this.panelBase);
-            this.flpLayout.Controls.Add(this.panelSettings);
-            this.flpLayout.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flpLayout.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flpLayout.Location = new System.Drawing.Point(0, 0);
-            this.flpLayout.Name = "flpLayout";
-            this.flpLayout.Padding = new System.Windows.Forms.Padding(5);
-            this.flpLayout.Size = new System.Drawing.Size(304, 160);
-            this.flpLayout.TabIndex = 2;
+            flpLayout.AutoSize = true;
+            flpLayout.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            flpLayout.Controls.Add(panelBase);
+            flpLayout.Controls.Add(panelSettings);
+            flpLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            flpLayout.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            flpLayout.Location = new System.Drawing.Point(0, 0);
+            flpLayout.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            flpLayout.Name = "flpLayout";
+            flpLayout.Padding = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            flpLayout.Size = new System.Drawing.Size(347, 213);
+            flpLayout.TabIndex = 2;
             // 
             // panelBase
             // 
-            this.panelBase.Controls.Add(this.cmdAbout);
-            this.panelBase.Controls.Add(this.cmdTrayify);
-            this.panelBase.Controls.Add(this.cbSettings);
-            this.panelBase.Controls.Add(this.cbJiggling);
-            this.panelBase.Location = new System.Drawing.Point(8, 8);
-            this.panelBase.Name = "panelBase";
-            this.panelBase.Size = new System.Drawing.Size(289, 28);
-            this.panelBase.TabIndex = 3;
+            panelBase.Controls.Add(cmdAbout);
+            panelBase.Controls.Add(cmdTrayify);
+            panelBase.Controls.Add(cbSettings);
+            panelBase.Controls.Add(cbJiggling);
+            panelBase.Location = new System.Drawing.Point(9, 11);
+            panelBase.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            panelBase.Name = "panelBase";
+            panelBase.Size = new System.Drawing.Size(330, 37);
+            panelBase.TabIndex = 3;
             // 
             // cmdAbout
             // 
-            this.cmdAbout.Location = new System.Drawing.Point(198, 2);
-            this.cmdAbout.Name = "cmdAbout";
-            this.cmdAbout.Size = new System.Drawing.Size(40, 23);
-            this.cmdAbout.TabIndex = 2;
-            this.cmdAbout.Text = "?";
-            this.cmdAbout.UseVisualStyleBackColor = true;
-            this.cmdAbout.Click += new System.EventHandler(this.cmdAbout_Click);
+            cmdAbout.Location = new System.Drawing.Point(226, 3);
+            cmdAbout.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            cmdAbout.Name = "cmdAbout";
+            cmdAbout.Size = new System.Drawing.Size(46, 31);
+            cmdAbout.TabIndex = 2;
+            cmdAbout.Text = "?";
+            cmdAbout.UseVisualStyleBackColor = true;
+            cmdAbout.Click += cmdAbout_Click;
             // 
             // cmdTrayify
             // 
-            this.cmdTrayify.Location = new System.Drawing.Point(244, 2);
-            this.cmdTrayify.Name = "cmdTrayify";
-            this.cmdTrayify.Size = new System.Drawing.Size(40, 23);
-            this.cmdTrayify.TabIndex = 3;
-            this.cmdTrayify.Text = "🔽";
-            this.cmdTrayify.UseVisualStyleBackColor = true;
-            this.cmdTrayify.Click += new System.EventHandler(this.cmdTrayify_Click);
+            cmdTrayify.Location = new System.Drawing.Point(279, 3);
+            cmdTrayify.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            cmdTrayify.Name = "cmdTrayify";
+            cmdTrayify.Size = new System.Drawing.Size(46, 31);
+            cmdTrayify.TabIndex = 3;
+            cmdTrayify.Text = "🔽";
+            cmdTrayify.UseVisualStyleBackColor = true;
+            cmdTrayify.Click += cmdTrayify_Click;
             // 
             // cbSettings
             // 
-            this.cbSettings.Location = new System.Drawing.Point(88, 5);
-            this.cbSettings.Name = "cbSettings";
-            this.cbSettings.Size = new System.Drawing.Size(77, 19);
-            this.cbSettings.TabIndex = 1;
-            this.cbSettings.Text = "Settings...";
-            this.cbSettings.UseVisualStyleBackColor = true;
-            this.cbSettings.CheckedChanged += new System.EventHandler(this.cbSettings_CheckedChanged);
+            cbSettings.Location = new System.Drawing.Point(101, 7);
+            cbSettings.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            cbSettings.Name = "cbSettings";
+            cbSettings.Size = new System.Drawing.Size(88, 25);
+            cbSettings.TabIndex = 1;
+            cbSettings.Text = "Settings...";
+            cbSettings.UseVisualStyleBackColor = true;
+            cbSettings.CheckedChanged += cbSettings_CheckedChanged;
             // 
             // cbJiggling
             // 
-            this.cbJiggling.AutoSize = true;
-            this.cbJiggling.Location = new System.Drawing.Point(10, 5);
-            this.cbJiggling.Name = "cbJiggling";
-            this.cbJiggling.Size = new System.Drawing.Size(72, 19);
-            this.cbJiggling.TabIndex = 0;
-            this.cbJiggling.Text = "Jiggling?";
-            this.cbJiggling.UseVisualStyleBackColor = true;
-            this.cbJiggling.CheckedChanged += new System.EventHandler(this.cbJiggling_CheckedChanged);
+            cbJiggling.AutoSize = true;
+            cbJiggling.Location = new System.Drawing.Point(11, 7);
+            cbJiggling.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            cbJiggling.Name = "cbJiggling";
+            cbJiggling.Size = new System.Drawing.Size(90, 24);
+            cbJiggling.TabIndex = 0;
+            cbJiggling.Text = "Jiggling?";
+            cbJiggling.UseVisualStyleBackColor = true;
+            cbJiggling.CheckedChanged += cbJiggling_CheckedChanged;
             // 
             // panelSettings
             // 
-            this.panelSettings.AutoSize = true;
-            this.panelSettings.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.panelSettings.Controls.Add(this.lbPeriod);
-            this.panelSettings.Controls.Add(this.tbPeriod);
-            this.panelSettings.Controls.Add(this.cbMinimize);
-            this.panelSettings.Controls.Add(this.cbZen);
-            this.panelSettings.Location = new System.Drawing.Point(8, 42);
-            this.panelSettings.Name = "panelSettings";
-            this.panelSettings.Size = new System.Drawing.Size(289, 110);
-            this.panelSettings.TabIndex = 2;
-            this.panelSettings.Visible = false;
+            panelSettings.AutoSize = true;
+            panelSettings.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            panelSettings.Controls.Add(lbPeriod);
+            panelSettings.Controls.Add(tbPeriod);
+            panelSettings.Controls.Add(cbMinimize);
+            panelSettings.Controls.Add(cbZen);
+            panelSettings.Location = new System.Drawing.Point(9, 56);
+            panelSettings.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            panelSettings.Name = "panelSettings";
+            panelSettings.Size = new System.Drawing.Size(330, 143);
+            panelSettings.TabIndex = 2;
+            panelSettings.Visible = false;
             // 
             // lbPeriod
             // 
-            this.lbPeriod.AutoSize = true;
-            this.lbPeriod.Location = new System.Drawing.Point(244, 41);
-            this.lbPeriod.Name = "lbPeriod";
-            this.lbPeriod.Size = new System.Drawing.Size(21, 15);
-            this.lbPeriod.TabIndex = 3;
-            this.lbPeriod.Text = "1 s";
+            lbPeriod.AutoSize = true;
+            lbPeriod.Location = new System.Drawing.Point(279, 55);
+            lbPeriod.Name = "lbPeriod";
+            lbPeriod.Size = new System.Drawing.Size(27, 20);
+            lbPeriod.TabIndex = 3;
+            lbPeriod.Text = "1 s";
             // 
             // tbPeriod
             // 
-            this.tbPeriod.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbPeriod.Location = new System.Drawing.Point(4, 62);
-            this.tbPeriod.Maximum = 60;
-            this.tbPeriod.Minimum = 1;
-            this.tbPeriod.Name = "tbPeriod";
-            this.tbPeriod.Size = new System.Drawing.Size(281, 45);
-            this.tbPeriod.TabIndex = 6;
-            this.tbPeriod.TickFrequency = 2;
-            this.tbPeriod.Value = 1;
-            this.tbPeriod.ValueChanged += new System.EventHandler(this.tbPeriod_ValueChanged);
+            tbPeriod.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            tbPeriod.Location = new System.Drawing.Point(5, 83);
+            tbPeriod.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            tbPeriod.Maximum = 10800;
+            tbPeriod.Minimum = 1;
+            tbPeriod.Name = "tbPeriod";
+            tbPeriod.Size = new System.Drawing.Size(321, 56);
+            tbPeriod.TabIndex = 6;
+            tbPeriod.TickFrequency = 2;
+            tbPeriod.Value = 1;
+            tbPeriod.ValueChanged += tbPeriod_ValueChanged;
             // 
             // cbMinimize
             // 
-            this.cbMinimize.AutoSize = true;
-            this.cbMinimize.Location = new System.Drawing.Point(10, 37);
-            this.cbMinimize.Name = "cbMinimize";
-            this.cbMinimize.Size = new System.Drawing.Size(123, 19);
-            this.cbMinimize.TabIndex = 5;
-            this.cbMinimize.Text = "Minimize on start?";
-            this.cbMinimize.UseVisualStyleBackColor = true;
-            this.cbMinimize.CheckedChanged += new System.EventHandler(this.cbMinimize_CheckedChanged);
+            cbMinimize.AutoSize = true;
+            cbMinimize.Location = new System.Drawing.Point(11, 49);
+            cbMinimize.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            cbMinimize.Name = "cbMinimize";
+            cbMinimize.Size = new System.Drawing.Size(153, 24);
+            cbMinimize.TabIndex = 5;
+            cbMinimize.Text = "Minimize on start?";
+            cbMinimize.UseVisualStyleBackColor = true;
+            cbMinimize.CheckedChanged += cbMinimize_CheckedChanged;
             // 
             // cbZen
             // 
-            this.cbZen.AutoSize = true;
-            this.cbZen.Location = new System.Drawing.Point(10, 11);
-            this.cbZen.Name = "cbZen";
-            this.cbZen.Size = new System.Drawing.Size(83, 19);
-            this.cbZen.TabIndex = 4;
-            this.cbZen.Text = "Zen jiggle?";
-            this.cbZen.UseVisualStyleBackColor = true;
-            this.cbZen.CheckedChanged += new System.EventHandler(this.cbZen_CheckedChanged);
+            cbZen.AutoSize = true;
+            cbZen.Location = new System.Drawing.Point(11, 15);
+            cbZen.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            cbZen.Name = "cbZen";
+            cbZen.Size = new System.Drawing.Size(105, 24);
+            cbZen.TabIndex = 4;
+            cbZen.Text = "Zen jiggle?";
+            cbZen.UseVisualStyleBackColor = true;
+            cbZen.CheckedChanged += cbZen_CheckedChanged;
             // 
             // niTray
             // 
-            this.niTray.Icon = ((System.Drawing.Icon)(resources.GetObject("niTray.Icon")));
-            this.niTray.Text = "Mouse Jiggler";
-            this.niTray.DoubleClick += new System.EventHandler(this.niTray_DoubleClick);
+            niTray.Icon = (System.Drawing.Icon)resources.GetObject("niTray.Icon");
+            niTray.Text = "Mouse Jiggler";
+            niTray.DoubleClick += niTray_DoubleClick;
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoSize = true;
-            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.ClientSize = new System.Drawing.Size(304, 160);
-            this.Controls.Add(this.flpLayout);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "MainForm";
-            this.Text = "Mouse Jiggler";
-            this.Load += new System.EventHandler(this.MainForm_Load);
-            this.Shown += new System.EventHandler(this.MainForm_Shown);
-            this.flpLayout.ResumeLayout(false);
-            this.flpLayout.PerformLayout();
-            this.panelBase.ResumeLayout(false);
-            this.panelBase.PerformLayout();
-            this.panelSettings.ResumeLayout(false);
-            this.panelSettings.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.tbPeriod)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            AutoSize = true;
+            AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            ClientSize = new System.Drawing.Size(347, 213);
+            Controls.Add(flpLayout);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "MainForm";
+            Text = "Mouse Jiggler";
+            Load += MainForm_Load;
+            Shown += MainForm_Shown;
+            flpLayout.ResumeLayout(false);
+            flpLayout.PerformLayout();
+            panelBase.ResumeLayout(false);
+            panelBase.PerformLayout();
+            panelSettings.ResumeLayout(false);
+            panelSettings.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)tbPeriod).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/MouseJiggler/MainForm.resx
+++ b/MouseJiggler/MainForm.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -57,8 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing.Common" name="System.Drawing.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
-  <data name="niTray.Icon" type="System.Drawing.Icon, System.Drawing.Common" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <metadata name="jiggleTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="niTray.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>153, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="niTray.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAICAQAAAAAADoAgAAJgAAABAQEAAAAAAAKAEAAA4DAAAoAAAAIAAAAEAAAAABAAQAAAAAAIAC
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAvwAAvwAAAL+/AL8AAAC/AL8Av78AAMDAwACAgIAAAAD/AAD/
@@ -80,7 +146,7 @@
         AAD+AQAA+AEAAOAAAADgAAAAwAAAAMABAADAAwAA4A8AAIA/AAAf/wAAf/8AAP//AAD//wAA//8AAA==
 </value>
   </data>
-  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing.Common" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAIAICAQAAAAAADoAgAAJgAAABAQEAAAAAAAKAEAAA4DAAAoAAAAIAAAAEAAAAABAAQAAAAAAIAC
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAvwAAvwAAAL+/AL8AAAC/AL8Av78AAMDAwACAgIAAAAD/AAD/

--- a/MouseJiggler/Program.cs
+++ b/MouseJiggler/Program.cs
@@ -120,8 +120,8 @@ namespace ArkaneSystems.MouseJiggler
                                                        ? "Period cannot be shorter than 1 second."
                                                        : null);
 
-            optPeriod.AddValidator (validate: p => p.GetValueOrDefault<int> () > 60
-                                                       ? "Period cannot be longer than 60 seconds."
+            optPeriod.AddValidator (validate: p => p.GetValueOrDefault<int> () > 10800
+                                                       ? "Period cannot be longer than 10800 seconds."
                                                        : null);
 
             optPeriod.Argument.SetDefaultValue (value: Settings.Default.JigglePeriod);


### PR DESCRIPTION
This extends the maximum allowed jiggle time from 60 seconds to 10800 seconds (3h). The new value is accepted both from command line and the GUI. Perhaps the slider in the GUI should be changed to a textfield, allow more precise values