### PR TITLE
Bump .NET version from 7 to 8

### DIFF
--- a/MouseJiggler/MouseJiggler.csproj
+++ b/MouseJiggler/MouseJiggler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows7.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>ArkaneSystems.MouseJiggler</RootNamespace>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Hi. I had some issues with this application. It was saying that .NET is not installed and .NET 6, 7, 8 SDKs were installed. When I compiled from source it was running fine on .NET 7, but I bumped my fork to .NET 8 anyway. Thanks for your great app! 