### PR TITLE
Added tray icon with right-click options, and fixed bug "Jiggling mouse every 0 s"

### DIFF
--- a/MouseJiggler/MainForm.Designer.cs
+++ b/MouseJiggler/MainForm.Designer.cs
@@ -43,6 +43,7 @@ namespace ArkaneSystems.MouseJiggler
             this.tbPeriod = new System.Windows.Forms.TrackBar();
             this.cbMinimize = new System.Windows.Forms.CheckBox();
             this.cbZen = new System.Windows.Forms.CheckBox();
+            this.trayMenu = new System.Windows.Forms.ContextMenuStrip();
             this.niTray = new System.Windows.Forms.NotifyIcon(this.components);
             this.flpLayout.SuspendLayout();
             this.panelBase.SuspendLayout();
@@ -179,9 +180,17 @@ namespace ArkaneSystems.MouseJiggler
             this.cbZen.Text = "Zen jiggle?";
             this.cbZen.UseVisualStyleBackColor = true;
             this.cbZen.CheckedChanged += new System.EventHandler(this.cbZen_CheckedChanged);
+            //
+            // trayMenu
+            //
+            this.trayMenu.Items.Add("Open", null, this.niTray_DoubleClick);
+            this.trayMenu.Items.Add("Start Juggling", null, this.trayMenu_ClickStartJuggling);
+            this.trayMenu.Items.Add("Stop Juggling", null, this.trayMenu_ClickStopJuggling);
+            this.trayMenu.Items.Add("Exit", null, this.trayMenu_ClickExit);
             // 
             // niTray
             // 
+            this.niTray.ContextMenuStrip = this.trayMenu;
             this.niTray.Icon = ((System.Drawing.Icon)(resources.GetObject("niTray.Icon")));
             this.niTray.Text = "Mouse Jiggler";
             this.niTray.DoubleClick += new System.EventHandler(this.niTray_DoubleClick);
@@ -229,6 +238,7 @@ namespace ArkaneSystems.MouseJiggler
         private System.Windows.Forms.Button cmdAbout;
         private System.Windows.Forms.NotifyIcon niTray;
         private System.Windows.Forms.Button cmdTrayify;
+        private System.Windows.Forms.ContextMenuStrip trayMenu;
     }
 }
 

--- a/MouseJiggler/MainForm.cs
+++ b/MouseJiggler/MainForm.cs
@@ -39,6 +39,11 @@ namespace ArkaneSystems.MouseJiggler
             this.cbMinimize.Checked = minimizeOnStartup;
             this.cbZen.Checked      = zenJiggleEnabled;
             this.tbPeriod.Value     = jigglePeriod;
+            this.JigglePeriod       = jigglePeriod;
+
+            // Component initial setting
+            this.trayMenu.Items[1].Visible = !this.cbJiggling.Checked;
+            this.trayMenu.Items[2].Visible = this.cbJiggling.Checked;
         }
 
         public bool JiggleOnStartup { get; }
@@ -65,6 +70,28 @@ namespace ArkaneSystems.MouseJiggler
         private void cmdAbout_Click (object sender, EventArgs e)
         {
             new AboutBox ().ShowDialog (owner: this);
+        }
+
+        private void trayMenu_ClickOpen(object sender, EventArgs e)
+        {
+            niTray_DoubleClick(sender, e);
+        }
+
+        private void trayMenu_ClickExit(object sender, EventArgs e)
+        {
+            Application.Exit ();
+        }
+
+        private void trayMenu_ClickStartJuggling(object sender, EventArgs e)
+        {
+            this.cbJiggling.Checked = true;
+            this.UpdateNotificationAreaText();
+        }
+
+        private void trayMenu_ClickStopJuggling(object sender, EventArgs e)
+        {
+            this.cbJiggling.Checked = false;
+            this.UpdateNotificationAreaText();
         }
 
         #region Property synchronization
@@ -98,6 +125,13 @@ namespace ArkaneSystems.MouseJiggler
         private void cbJiggling_CheckedChanged (object sender, EventArgs e)
         {
             this.jiggleTimer.Enabled = this.cbJiggling.Checked;
+            updateTrayMenu();
+        }
+
+        private void updateTrayMenu()
+        {
+            this.trayMenu.Items[1].Visible = !this.cbJiggling.Checked;
+            this.trayMenu.Items[2].Visible = this.cbJiggling.Checked;
         }
 
         private void jiggleTimer_Tick (object sender, EventArgs e)


### PR DESCRIPTION
Feat: This PR adds a system tray icon with right-click options to the application. The options include:

1. Open the main window.

2. Exit the application.

3. Toggle the jiggle state on/off.

These features improve user control over the application without needing to keep the main window open.

Fix: Uninitialized JigglePeriod results in "Jiggling mouse every 0 s" message

1. Issue occurred when Jiggling was enabled and the app minimized to tray without setting the period.

2. The JigglePeriod variable was not properly initialized in the constructor. Modifying the value of tbPeriod in the constructor does not call the function tbPeriod_ValueChanged.

3. Fixed by assigning JigglePeriod in the MainForm constructor.