### PR TITLE
Replace old PInvoke.User32 library with new Windows.CsWin32 generator.

### DIFF
--- a/MouseJiggler/Helpers.cs
+++ b/MouseJiggler/Helpers.cs
@@ -12,7 +12,8 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using PInvoke;
+using Windows.Win32;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 #endregion
 
@@ -25,7 +26,7 @@ internal static class Helpers
     /// <summary>
     ///     Constant value signifying a request to attach to the console of the parent process.
     /// </summary>
-    internal const int AttachParentProcess = -1;
+    internal const uint AttachParentProcess = uint.MaxValue;
 
     #endregion Console management
 
@@ -37,24 +38,24 @@ internal static class Helpers
     /// <param name="delta">The mouse will be moved by delta pixels along both X and Y.</param>
     internal static void Jiggle(int delta)
     {
-        var inp = new User32.INPUT
+    var inp = new INPUT
+    {
+      type = INPUT_TYPE.INPUT_MOUSE,
+      Anonymous = new INPUT._Anonymous_e__Union
+      {
+        mi = new MOUSEINPUT
         {
-            type = User32.InputType.INPUT_MOUSE,
-            Inputs = new User32.INPUT.InputUnion
-            {
-                mi = new User32.MOUSEINPUT
-                {
-                    dx = delta,
-                    dy = delta,
-                    mouseData = 0,
-                    dwFlags = User32.MOUSEEVENTF.MOUSEEVENTF_MOVE,
-                    time = 0,
-                    dwExtraInfo_IntPtr = IntPtr.Zero
-                }
-            }
-        };
-
-        var returnValue = User32.SendInput(1, new[] { inp }, Marshal.SizeOf<User32.INPUT>());
+          dx = delta,
+          dy = delta,
+          mouseData = 0,
+          dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_MOVE,
+          time = 0,
+          dwExtraInfo = 0
+        }
+      }
+    };
+    
+        var returnValue = PInvoke.SendInput(new ReadOnlySpan<INPUT>(in inp), Marshal.SizeOf<INPUT>());
 
         if (returnValue == 1) return;
         var errorCode = Marshal.GetLastWin32Error();

--- a/MouseJiggler/Helpers.cs
+++ b/MouseJiggler/Helpers.cs
@@ -38,22 +38,22 @@ internal static class Helpers
     /// <param name="delta">The mouse will be moved by delta pixels along both X and Y.</param>
     internal static void Jiggle(int delta)
     {
-    var inp = new INPUT
-    {
-      type = INPUT_TYPE.INPUT_MOUSE,
-      Anonymous = new INPUT._Anonymous_e__Union
-      {
-        mi = new MOUSEINPUT
+        var inp = new INPUT
         {
-          dx = delta,
-          dy = delta,
-          mouseData = 0,
-          dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_MOVE,
-          time = 0,
-          dwExtraInfo = 0
-        }
-      }
-    };
+          type = INPUT_TYPE.INPUT_MOUSE,
+          Anonymous = new INPUT._Anonymous_e__Union
+          {
+            mi = new MOUSEINPUT
+            {
+              dx = delta,
+              dy = delta,
+              mouseData = 0,
+              dwFlags = MOUSE_EVENT_FLAGS.MOUSEEVENTF_MOVE,
+              time = 0,
+              dwExtraInfo = 0
+            }
+          }
+        };
     
         var returnValue = PInvoke.SendInput(new ReadOnlySpan<INPUT>(in inp), Marshal.SizeOf<INPUT>());
 

--- a/MouseJiggler/MouseJiggler.csproj
+++ b/MouseJiggler/MouseJiggler.csproj
@@ -52,9 +52,13 @@ Command line options:
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    
-    <PackageReference Include="PInvoke.User32" Version="0.7.124" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.162">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MouseJiggler/NativeMethods.txt
+++ b/MouseJiggler/NativeMethods.txt
@@ -1,0 +1,3 @@
+﻿AttachConsole
+FreeConsole
+SendInput

--- a/MouseJiggler/Program.cs
+++ b/MouseJiggler/Program.cs
@@ -17,7 +17,7 @@ using System.Threading;
 using System.Windows.Forms;
 using ArkaneSystems.MouseJiggler.Properties;
 using JetBrains.Annotations;
-using PInvoke;
+using Windows.Win32;
 
 #endregion
 
@@ -33,7 +33,7 @@ public static class Program
     public static int Main(string[] args)
     {
         // Attach to the parent process's console so we can display help, version information, and command-line errors.
-        Kernel32.AttachConsole(Helpers.AttachParentProcess);
+        PInvoke.AttachConsole(Helpers.AttachParentProcess);
 
         // Ensure that we are the only instance of the Mouse Jiggler currently running.
         var instance = new Mutex(false, "single instance: ArkaneSystems.MouseJiggler");
@@ -58,7 +58,7 @@ public static class Program
             instance.Close();
 
             // Detach from the parent console.
-            Kernel32.FreeConsole();
+            PInvoke.FreeConsole();
         }
     }
 


### PR DESCRIPTION
This is one of the outstanding package issues, unfortunately not the blocker. But it was there and now it's dealt with - basically swapping out the obsoleted package for the recommended replacement.

(Whether or not you merge this now, please don't delete the branch so I can do the next fix in it also.)
