### PR TITLE
Feat: Add Show Settings flag

### DIFF
--- a/MouseJiggler/MainForm.cs
+++ b/MouseJiggler/MainForm.cs
@@ -24,11 +24,11 @@ public partial class MainForm : Form
     ///     Constructor for use by the form designer.
     /// </summary>
     public MainForm()
-        : this(false, false, false, 1)
+        : this(false, false, false, 1, false)
     {
     }
 
-    public MainForm(bool jiggleOnStartup, bool minimizeOnStartup, bool zenJiggleEnabled, int jigglePeriod)
+    public MainForm(bool jiggleOnStartup, bool minimizeOnStartup, bool zenJiggleEnabled, int jigglePeriod, bool showSettings)
     {
         InitializeComponent();
 
@@ -48,6 +48,13 @@ public partial class MainForm : Form
             // Handle invalid jigglePeriod value, e.g., set to default or raise an error
             tbPeriod.Value = tbPeriod.Minimum; // or any default value within the range
         JigglePeriod = jigglePeriod;
+
+        // Show settings panel on startup if requested
+        if (showSettings)
+        {
+            cbSettings.Checked = true;
+            panelSettings.Visible = true;
+        }
 
         // Component initial setting
         trayMenu.Items[1].Visible = !cbJiggling.Checked;

--- a/MouseJiggler/MouseJiggler.csproj
+++ b/MouseJiggler/MouseJiggler.csproj
@@ -25,6 +25,7 @@ Command line options:
 -m --minimized: Start minimized
 -z --zen: Start with zen (invisible) jiggling enabled
 -s 60 --seconds 60: Set number of seconds for the jiggle interval (1-10800)
+-g --settings: Start with settings panel displayed
     </Description>
     <Copyright>Copyright © Alistair J. R. Young 2007-2025</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/MouseJiggler/Program.cs
+++ b/MouseJiggler/Program.cs
@@ -62,7 +62,7 @@ public static class Program
         }
     }
 
-    private static int RootHandler(bool jiggle, bool minimized, bool zen, int seconds)
+    private static int RootHandler(bool jiggle, bool minimized, bool zen, int seconds, bool settings)
     {
         // Prepare Windows Forms to run the application.
         Application.SetHighDpiMode(HighDpiMode.SystemAware);
@@ -73,7 +73,8 @@ public static class Program
         var mainForm = new MainForm(jiggle,
             minimized,
             zen,
-            seconds);
+            seconds,
+            settings);
 
         Application.Run(mainForm);
 
@@ -87,7 +88,7 @@ public static class Program
         {
             Description = "Virtually jiggles the mouse, making the computer seem not idle.",
             Handler =
-                CommandHandler.Create(new Func<bool, bool, bool, int, int>(RootHandler))
+                CommandHandler.Create(new Func<bool, bool, bool, int, bool, int>(RootHandler))
         };
 
         // -j --jiggle
@@ -120,6 +121,13 @@ public static class Program
         optPeriod.AddValidator(p =>
             p.GetValueOrDefault<int>() > 10800 ? "Period cannot be longer than 10800 seconds." : null);
         rootCommand.AddOption(optPeriod);
+
+        // -g --settings
+        Option optSettings = new(["--settings", "-g"], "Start with settings panel displayed.")
+        {
+            Argument = new Argument<bool>(() => false)
+        };
+        rootCommand.AddOption(optSettings);
 
         // Build the command line parser.
         return rootCommand;

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Options:
   -m, --minimized            Start minimized (sets persistent option). [default: False]
   -z, --zen                  Start with zen (invisible) jiggling enabled (sets persistent option). [default: False]
   -s, --seconds <seconds>    Set number of seconds for the jiggle interval (sets persistent option). [default: 60]
+  -g, --settings             Start with settings panel displayed.
   --version                  Show version information
   -?, -h, --help             Show help and usage information
 ```


### PR DESCRIPTION
This PR adds new (-g, --settings) flag that allows you to start MouseJiggler with the Settings opened.
Resolves #71 