### PR TITLE
Set color mode to system in Windows Forms startup

### DIFF
--- a/MouseJiggler/Program.cs
+++ b/MouseJiggler/Program.cs
@@ -74,7 +74,7 @@ public static class Program
     _ = Application.SetHighDpiMode (HighDpiMode.SystemAware);
     Application.EnableVisualStyles ();
     Application.SetCompatibleTextRenderingDefault (false);
-    Application.SetColorMode(SystemColorMode.System);
+    Application.SetColorMode (SystemColorMode.System);
 
     // Detach from console before running the application, as we won't be needing it anymore.
     if (AttachedToConsole)

--- a/MouseJiggler/Program.cs
+++ b/MouseJiggler/Program.cs
@@ -74,6 +74,7 @@ public static class Program
     _ = Application.SetHighDpiMode (HighDpiMode.SystemAware);
     Application.EnableVisualStyles ();
     Application.SetCompatibleTextRenderingDefault (false);
+    Application.SetColorMode(SystemColorMode.System);
 
     // Detach from console before running the application, as we won't be needing it anymore.
     if (AttachedToConsole)


### PR DESCRIPTION
Added Application.SetColorMode(SystemColorMode.System) to align the app's color mode with the system setting.

Dark mode:

<img width="310" height="227" alt="{EA8C4DF7-1927-4F65-9624-975E932B5400}" src="https://github.com/user-attachments/assets/7efe0d22-4b54-4828-bfa8-1f4c5336bace" />

<img width="546" height="351" alt="{3376792D-0356-430B-9F12-B89259A565F8}" src="https://github.com/user-attachments/assets/df19b072-343e-40f5-a116-60b13896714d" />



Normal/Light mode is the same as before.